### PR TITLE
docs: cite official website on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,6 +138,7 @@
       <ul>
         <li>內容由客戶自主提供。</li>
         <li>本平台非律師事務所官方網站。</li>
+        <li>官方資訊請參考 <a href="https://www.honganlaw.com/" target="_blank" rel="noopener">鴻安法律事務所官方網站</a>。</li>
         <li>見證內容不構成法律建議。</li>
         <li>個別案件結果可能因情況而異。</li>
       </ul>


### PR DESCRIPTION
## Summary
- reference the official law firm's website in the disclaimer section of the homepage

## Testing
- `npx -y htmlhint index.html` *(fails: 403 Forbidden fetching package)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d997acd288328beddf39f819af8b2