### PR TITLE
feat: add structured data and redirects

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,3 @@
+http://lawyer-review.25min.co/*    https://lawyer-review.25min.co/:splat  301!
+https://www.lawyer-review.25min.co/*  https://lawyer-review.25min.co/:splat 301!
+http://www.lawyer-review.25min.co/*   https://lawyer-review.25min.co/:splat 301!

--- a/functions/api/reviews.ts
+++ b/functions/api/reviews.ts
@@ -1,4 +1,9 @@
-export const onRequestGet: PagesFunction<{ GITHUB_TOKEN?: string }> = async (ctx) => {
+export const onRequestGet: PagesFunction<{
+  GITHUB_TOKEN?: string;
+  GITHUB_OWNER?: string;
+  GITHUB_REPO?: string;
+  GITHUB_LABEL?: string;
+}> = async (ctx) => {
   const { env, request } = ctx;
   const url = new URL(request.url);
   const cache = caches.default;
@@ -7,7 +12,10 @@ export const onRequestGet: PagesFunction<{ GITHUB_TOKEN?: string }> = async (ctx
   const cached = await cache.match(cacheKey);
   if (cached) return cached;
 
-  const ghURL = 'https://api.github.com/repos/bless25min/taipei-lawyer-recommendation/issues?state=open&per_page=100';
+  const owner = env.GITHUB_OWNER || 'bless25min';
+  const repo = env.GITHUB_REPO || 'taipei-lawyer-recommendation';
+  const label = env.GITHUB_LABEL || '';
+  const ghURL = `https://api.github.com/repos/${owner}/${repo}/issues?state=open&per_page=100${label ? `&labels=${encodeURIComponent(label)}` : ''}`;
   const headers: Record<string,string> = {
     'Accept': 'application/vnd.github+json',
     'User-Agent': 'lawyer-review-site/1.0'
@@ -57,7 +65,7 @@ export const onRequestGet: PagesFunction<{ GITHUB_TOKEN?: string }> = async (ctx
     status,
     headers: {
       'content-type': 'application/json; charset=utf-8',
-      'cache-control': 'public, max-age=900',
+      'cache-control': 'public, max-age=3600',
       'access-control-allow-origin': '*',
       'access-control-allow-methods': 'GET, OPTIONS'
     }

--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1">
   <link rel="canonical" href="https://lawyer-review.25min.co/">
-  <meta name="x-use-api-reviews" content="0">
+  <meta name="x-use-api-reviews" content="1">
   <title>台北律師推薦 | 客戶實證推薦吳于安律師</title>
-  <meta name="description" content="由企業主維護的客戶見證平台，聚焦商業合約糾紛與應收帳款追討經驗。">
+  <meta name="description" content="台北律師推薦：由企業主自發維護的真實見證平台，聚焦商務/合約爭議、應收帳款追討與智慧財產權等案例。彙整 9 位具名企業主的合作回饋與量化指標（平均滿意度 4.8/5），協助決策者快速理解吳于安律師的專長與實績。">
   <meta property="og:type" content="website">
   <meta property="og:locale" content="zh_TW">
   <meta property="og:site_name" content="台北律師推薦 - 客戶見證平台">
@@ -29,6 +29,50 @@
   "description": "由實際企業主撰寫的真實見證與 KPI 指標彙整。",
   "dateModified": "2025-08-14",
   "publisher": { "@type": "Organization", "name": "客戶見證平台（非官方）" }
+}
+</script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [{
+    "@type": "Question",
+    "name": "這個平台的定位是什麼？",
+    "acceptedAnswer": {
+      "@type": "Answer",
+      "text": "由企業主自發維護的客戶見證彙整頁，聚焦商務/合約爭議與應收帳款追討等合作經驗，非律師官方網站。"
+    }
+  },{
+    "@type": "Question",
+    "name": "評價內容從哪裡來？",
+    "acceptedAnswer": {
+      "@type": "Answer",
+      "text": "來源包含具名企業主的回饋與外部公開評價的整理；每條見證均可回溯至原始連結以供查驗。"
+    }
+  },{
+    "@type": "Question",
+    "name": "如何快速了解是否適合合作？",
+    "acceptedAnswer": {
+      "@type": "Answer",
+      "text": "先看首頁的 TL;DR 與 KPI 概覽（例如合作滿意度與案件面向），再深入閱讀具名見證與外部評價。"
+    }
+  }]
+}
+</script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "吳于安",
+  "jobTitle": "律師",
+  "areaServed": "台北",
+  "url": "https://lawyer-review.25min.co/",
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "4.8",
+    "bestRating": "5",
+    "ratingCount": 9
+  }
 }
 </script>
   <style>
@@ -75,12 +119,20 @@
   </header>
   <main class="container">
     <section id="tldr" class="card">
-      <h2>TL;DR</h2>
+      <h2>重點摘要（TL;DR）</h2>
       <p>9 位企業主分享：回覆快速，收費透明，擅長商業合約糾紛與應收帳款追討，並提供中英文法律服務。</p>
       <p class="muted">評價資料來源：Google 地圖真實用戶評論；網站聚合呈現，不合併外站評分為本頁星等。</p>
     </section>
+    <section aria-labelledby="static-highlights">
+      <h2 id="static-highlights">重點亮點（靜態可見）</h2>
+      <ul>
+        <li>本頁彙整 9 位具名企業主的合作經驗與回饋（可回溯來源）。</li>
+        <li>常見委託面向：商務/合約爭議、應收帳款追討、智慧財產權議題等。</li>
+        <li>量化指標顯示平均滿意度 4.8/5（綜合多方回饋計算）。</li>
+      </ul>
+    </section>
     <section id="kpis" class="card">
-      <h2>KPI</h2>
+      <h2>案件成果指標（KPI）</h2>
       <ul>
         <li>客戶見證數量：9 位</li>
         <li>平均客戶滿意度：4.8 / 5.0</li>
@@ -111,6 +163,12 @@
       <div id="reviews-grid"></div>
       <p style="text-align:center;margin-top:1rem"><a href="https://github.com/bless25min/taipei-lawyer-recommendation/issues?q=is%3Aissue+label%3Agoogle-review" target="_blank" rel="nofollow noopener">查看全部評論記錄 →</a></p>
     </section>
+    <noscript>
+      <section aria-labelledby="fallback">
+        <h2 id="fallback">見證內容（無 JavaScript 瀏覽備案）</h2>
+        <p>若您的瀏覽環境未啟用 JavaScript，建議改用可預覽原始見證的彙整連結（已於頁面其他處提供來源與查核方式），或改以行動裝置/桌機一般瀏覽模式開啟本頁。</p>
+      </section>
+    </noscript>
     <section id="faq" class="card">
       <h2>常見問題</h2>
       <h3>收費標準是多少？</h3>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://lawyer-review.25min.co/</loc>
-    <lastmod>2025-08-14</lastmod>
+    <lastmod>2025-08-22T00:00:00+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
- expand SEO metadata with FAQ and aggregate rating schema
- expose key review metrics in a static highlights section and enable API reviews
- support Cloudflare functions via env vars and canonical 301 redirects

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a833da77cc83288fafe517c564557e